### PR TITLE
улучшил конструктор соединения с брокером

### DIFF
--- a/example/sandbox/sandbox.go
+++ b/example/sandbox/sandbox.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"context"
-	"github.com/vodolaz095/go-investAPI/investapi"
 	"log"
+
+	"github.com/vodolaz095/go-investAPI/investapi"
 )
 
 /*
@@ -13,7 +14,7 @@ import (
 const token = "тутДолженБытьТокен" // https://tinkoff.github.io/investAPI/grpc/#tinkoff-invest-api_1
 
 func main() {
-	client, err := investapi.New(token)
+	client, err := investapi.NewWithCustomEndpoint(token, investapi.SandboxEndpoint)
 	if err != nil {
 		log.Fatalf("%s : при соединении с investAPI", err)
 	}

--- a/investapi/client.go
+++ b/investapi/client.go
@@ -4,31 +4,37 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 )
 
-// DefaultEndpoint - это доменное имя по умолчанию, на котором работает InvestAPI
-const DefaultEndpoint = "invest-public-api.tinkoff.ru"
+// DefaultEndpoint - это адрес, на котором работает продукционное окружение InvestAPI
+const DefaultEndpoint = "invest-public-api.tinkoff.ru:443"
+
+// SandboxEndpoint - это адрес, на котором работает тестовое окружение
+const SandboxEndpoint = "sandbox-invest-public-api.tinkoff.ru:443"
 
 // tokenAuth используется для описания стратегии авторизации GRPC клиента
 type tokenAuth struct {
 	// Token - это ключ доступа, который можно получить отсюда - // https://tinkoff.github.io/investAPI/grpc/#tinkoff-invest-api_1
 	Token string
+	// Secure - флаг, включающий требование шифрования соединения
+	Secure bool
 }
 
 // GetRequestMetadata используется для авторизации с помощью Bearer стратегии
-func (t tokenAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
+func (ta tokenAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
 	return map[string]string{
-		"Authorization": "Bearer " + t.Token,
+		"Authorization": "Bearer " + ta.Token,
 	}, nil
 }
 
 // RequireTransportSecurity требует, чтобы транспорт был защищённым
-func (tokenAuth) RequireTransportSecurity() bool {
-	return true
+func (ta tokenAuth) RequireTransportSecurity() bool {
+	return ta.Secure
 }
 
 // Client - это структура для доступа к API, в которой есть соединение и сгенерированные клиенты для всех сервисов
@@ -56,25 +62,45 @@ func (c *Client) Ping(_ context.Context) (err error) {
 }
 
 // New создаёт новый клиент для доступа к API, используя Ключ доступа как аргумент
-func New(token string) (client *Client, err error) {
-	return NewWithCustomEndpoint(token, "invest-public-api.tinkoff.ru")
+func New(token string, opts ...grpc.DialOption) (client *Client, err error) {
+	return NewWithCustomEndpoint(token, DefaultEndpoint, opts...)
 }
 
-// NewWithCustomEndpoint создаёт новый клиент для доступа к API, используя Ключ доступа и доменное имя адреса API как аргументы
-func NewWithCustomEndpoint(token, endpoint string) (client *Client, err error) {
-	return NewWithOpts(token, endpoint, make([]grpc.DialOption, 0)...)
+// NewWithCustomEndpoint создаёт новый клиент для доступа к API, используя Ключ доступа и д оменное имя адреса API как аргументы
+func NewWithCustomEndpoint(token, endpoint string, opts ...grpc.DialOption) (client *Client, err error) {
+	return NewWithOpts(token, endpoint, opts...)
 }
 
-// NewWithOpts создаёт новый клиент для доступа к API, используя Ключ доступа как аргумент, доменное имя и вариадическую переменную opts с параметрами вида grpc.DialOption для настройки соединения
+// NewWithOpts создаёт новый клиент для доступа к API, используя Ключ доступа как аргумент, доменное имя и вариадическую
+// переменную opts с параметрами вида grpc.DialOption для настройки соединения
 func NewWithOpts(token, endpoint string, opts ...grpc.DialOption) (client *Client, err error) {
-	opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-		ServerName: endpoint,
-	})))
-	opts = append(opts, grpc.WithPerRPCCredentials(tokenAuth{
-		Token: token,
-	}))
-	opts = append(opts, grpc.WithUserAgent("https://github.com/vodolaz095/go-investAPI"))
-	conn, err := grpc.Dial(fmt.Sprintf("%s:443", endpoint), opts...)
+	opts = append(opts,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			ServerName: strings.Split(endpoint, ":")[0],
+		})),
+		grpc.WithPerRPCCredentials(tokenAuth{Token: token, Secure: true}),
+		grpc.WithUserAgent("https://github.com/vodolaz095/go-investAPI"),
+	)
+	return makeClient(endpoint, opts...)
+}
+
+// NewInsecure создаёт новый клиент с ВЫКЛЮЧЕННОЙ проверкой подлинности TLS сертификатов для доступа к API, используя
+// Ключ доступа как аргумент, доменное имя и вариадическую переменную opts с параметрами вида grpc.DialOption для настройки соединения
+// Этот клиент лучше не использовать за пределами тестовых окружений!
+func NewInsecure(token, endpoint string, opts ...grpc.DialOption) (client *Client, err error) {
+	opts = append(opts,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			ServerName:         strings.Split(endpoint, ":")[0],
+			InsecureSkipVerify: true, // ВАЖНО
+		})),
+		grpc.WithPerRPCCredentials(tokenAuth{Token: token, Secure: false}),
+		grpc.WithUserAgent("https://github.com/vodolaz095/go-investAPI"),
+	)
+	return makeClient(endpoint, opts...)
+}
+
+func makeClient(endpoint string, opts ...grpc.DialOption) (client *Client, err error) {
+	conn, err := grpc.NewClient(endpoint, opts...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
1) добавлена константа SandboxEndpoint - строка соединения с окружением "песочницей"

2) Строка соединения с брокером не включает зашитый 443 порт по умолчанию, можно попытаться соединиться с локальными mock серверами, которые работают на нестандартных для grpc портах 

3) В функции New, NewWithCustomEndpoint добавлен вариадический аргумент опций grpc соединения как в NewWithOpts

4) Добавлена функция NewInsecure, которая создаёт новое соединение без проверки подлинности tls сертификатов